### PR TITLE
Include the juce::WindowsHooks for keyboard access

### DIFF
--- a/include/sst/clap_juce_shim/clap_juce_shim.h
+++ b/include/sst/clap_juce_shim/clap_juce_shim.h
@@ -72,7 +72,6 @@ struct ClapJuceShim
 
     EditorProvider *editorProvider;
 
-
     double getGuiScale() const
     {
 #if SHIM_WINDOWS || SHIM_LINUX

--- a/src/sst/clap_juce_shim/clap_juce_shim_impl.cpp
+++ b/src/sst/clap_juce_shim/clap_juce_shim_impl.cpp
@@ -23,6 +23,10 @@
 
 #include <memory>
 
+#if JUCE_WINDOWS
+#include <juce_gui_basics/native/juce_WindowsHooks_windows.h>
+#endif
+
 #define FLF __FILE__ << ":" << __LINE__ << " " << __func__ << " "
 
 #define DO_TRACE 0
@@ -42,6 +46,10 @@ namespace details
 {
 struct Implementor
 {
+#if JUCE_WINDOWS
+    juce::detail::WindowsHooks hooks;
+#endif
+
     struct ImplParent : juce::Component
     {
         std::string displayName;


### PR DESCRIPTION
VST3 pretends to help with the keyboard. JUCE works aroudn this by hacking into the windows event queue. To do that you need to set that up, and the shim did not.

Now the shim does.